### PR TITLE
feat(desktop-ui): Button 컴포넌트 disabled 대응 및 panda css 적용

### DIFF
--- a/packages/ui-desktop/src/Button/Button.stories.tsx
+++ b/packages/ui-desktop/src/Button/Button.stories.tsx
@@ -1,0 +1,37 @@
+import { Button, ButtonProps } from './Button';
+
+const TextStory = {
+  title: 'Component/Button',
+  argTypes: {
+    children: { control: 'text' },
+    display: {
+      control: {
+        type: 'select',
+        options: ['inline', 'block'],
+      },
+    },
+    size: {
+      control: {
+        type: 'select',
+        options: ['small', 'medium', 'large'],
+      },
+    },
+    bgColor: { control: 'color' },
+    textColor: { control: 'color' },
+    disabled: { control: 'boolean' },
+  },
+  component: Button,
+};
+
+export const Playground = {
+  args: {
+    children: 'button',
+    display: 'inline',
+    size: 'medium',
+    bgColor: '#9CC5A1',
+    textColor: '#1F2421',
+  },
+  render: (args: ButtonProps) => <Button {...args} />,
+};
+
+export default TextStory;

--- a/packages/ui-desktop/src/Button/Button.tsx
+++ b/packages/ui-desktop/src/Button/Button.tsx
@@ -1,8 +1,8 @@
 import { ButtonHTMLAttributes, CSSProperties, Ref, forwardRef } from 'react';
+import { cx } from '../styled-system/css';
+import { buttonBaseStyle, buttonDisplayStyle, buttonSizeStyle } from './style';
 
-// TODO: disable의 경우도 챙겨야 함
-
-type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+export type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
   display?: 'inline' | 'block';
   size?: 'small' | 'medium' | 'large';
   bgColor?: CSSProperties['backgroundColor'];
@@ -16,11 +16,14 @@ export const Button = forwardRef((props: ButtonProps, ref: Ref<HTMLButtonElement
    <button
     ref={ref}
     style={{
-      ...getButtonBaseStyle,
-      ...getDisplayStyle(display),
-      ...getSizeStyle(size),
-      ...getButtonColorStyle(bgColor, textColor),
+      color: textColor ?? '#1F2421',
+      backgroundColor: bgColor ?? '#9CC5A1',
     }}
+    className={cx(
+      buttonBaseStyle,
+      buttonDisplayStyle[display],
+      buttonSizeStyle[size],
+    )}
     {...restProps}
   >
     {children}
@@ -29,58 +32,3 @@ export const Button = forwardRef((props: ButtonProps, ref: Ref<HTMLButtonElement
 });
 
 Button.displayName = 'Button';
-
-const getButtonBaseStyle = {
-  margin: 0,
-  fontWeight: 600,
-  verticalAlign: 'middle',
-  cursor: 'pointer',
-  border: 'none',
-  borderRadius: '10px',
-};
-
-const getDisplayStyle = (display: ButtonProps['display']) => {
-  switch (display) {
-    case 'block':
-      return {
-        display: 'block',
-        width: '100%',
-      };
-    default:
-    case 'inline':
-      return {
-        display: 'inline-block',
-      };
-  }
-};
-
-const getSizeStyle = (size: ButtonProps['size']) => {
-  switch (size) {
-    case 'small':
-      return {
-        padding: '7px 12px',
-        borderRadius: '6px',
-        fontSize: '14px',
-      };
-    case 'large':
-      return {
-        padding: '11px 22px',
-        borderRadius: '8px',
-        fontSize: '16px',
-      };
-    default:
-    case 'medium':
-      return {
-        padding: '9px 16px',
-        borderRadius: '7px',
-        fontSize: '15px',
-      };
-  }
-};
-
-const getButtonColorStyle = (bgColor: ButtonProps['bgColor'], textColor: ButtonProps['textColor']) => {
-  return {
-    backgroundColor: bgColor ?? '#9CC5A1',
-    color: textColor ?? '#1F2421',
-  };
-};

--- a/packages/ui-desktop/src/Button/style.ts
+++ b/packages/ui-desktop/src/Button/style.ts
@@ -1,0 +1,52 @@
+import { css } from '../styled-system/css';
+
+export const buttonBaseStyle = css({
+  margin: 0,
+  fontWeight: 600,
+  verticalAlign: 'middle',
+  cursor: 'pointer',
+  border: 'none',
+  borderRadius: '10px',
+
+  '&:disabled': {
+    opacity: 0.5,
+    cursor: 'not-allowed',
+  },
+
+  '&:not(:disabled)': {
+    '&:hover': {
+      opacity: 0.9,
+    },
+    '&:active': {
+      filter: 'contrast(0.9)',
+    },
+  },
+});
+
+export const buttonDisplayStyle = {
+  inline: css({
+    display: 'inline-block',
+  }),
+  block: css({
+    display: 'block',
+    width: '100%',
+  }),
+};
+
+export const buttonSizeStyle = {
+  small: css({
+    fontSize: '14px',
+    padding: '7px 12px',
+    borderRadius: '6px',
+  }),
+  medium: css({
+    fontSize: '15px',
+    padding: '9px 16px',
+    borderRadius: '7px',
+  }),
+  large: css({
+    fontSize: '16px',
+    padding: '11px 22px',
+    borderRadius: '8px',
+  }),
+};


### PR DESCRIPTION
## Overview

<img width="1552" alt="image" src="https://github.com/Tech-Frontier/tech-frontier-packages/assets/76990149/5f79e5ce-ff56-47f4-ac55-504e8b4617ec">

disabled, hover, active 스타일 추가햇어용