### PR TITLE
feat(desktop-ui): Tag 컴포넌트에 panda css 적용 

### DIFF
--- a/packages/ui-desktop/src/Tag/Tag.stories.tsx
+++ b/packages/ui-desktop/src/Tag/Tag.stories.tsx
@@ -1,0 +1,28 @@
+import { Tag, TagProps } from './Tag';
+
+const Story = {
+  title: 'Component/Tag',
+  argTypes: {
+    children: { control: 'text' },
+    size: {
+      control: {
+        type: 'select',
+        options: ['small', 'medium', 'large'],
+      },
+    },
+    bgColor: { control: 'color' },
+    textColor: { control: 'color' },
+    borderColor: { control: 'color' },
+  },
+  component: Tag,
+};
+
+export const Playground = {
+  args: {
+    children: 'Tag',
+    size: 'medium',
+  },
+  render: (args: TagProps) => <Tag {...args} />,
+};
+
+export default Story;

--- a/packages/ui-desktop/src/Tag/Tag.tsx
+++ b/packages/ui-desktop/src/Tag/Tag.tsx
@@ -1,13 +1,11 @@
 import { CSSProperties, HTMLAttributes } from 'react';
+import { cx } from '../styled-system/css';
+import { tagBaseStyle, tagSizeStyle } from './style';
 
-interface TagProps extends HTMLAttributes<HTMLSpanElement> {
+export interface TagProps extends HTMLAttributes<HTMLSpanElement> {
   size?: 'small' | 'medium' | 'large';
-  variant?: 'border' | 'default';
   bgColor?: CSSProperties['backgroundColor'];
   textColor?: CSSProperties['color'];
-
-  /** @description variant가 border일 때만 적용됩니다. */
-  borderColor?: CSSProperties['borderColor'];
 }
 
 // NOTE: leftAddon, rightAddon 추후 지원...
@@ -17,73 +15,16 @@ export function Tag(
     bgColor,
     textColor,
     size = 'medium',
-    variant = 'default',
-    borderColor,
     ...restProps
   }: TagProps) {
   return (
     <span
       style={{
-        ...getTagBaseStyle,
-        ...getTagSizeStyle(size),
-        ...getTagVariantStyle(variant, borderColor),
-        ...getTagColorStyle(bgColor, textColor),
+        color: textColor ?? '#DCE1DE',
+        backgroundColor: bgColor ?? '#9CC5A1',
       }}
+      className={cx(tagBaseStyle, tagSizeStyle[size])}
       {...restProps}
     />
   );
 }
-
-const getTagBaseStyle = {
-  display: 'inline-flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  fontWeight: '700',
-  cursor: 'pointer',
-};
-
-const getTagSizeStyle = (size: TagProps['size']) => {
-  switch (size) {
-    case 'small':
-      return {
-        fontSize: '13px',
-        padding: '1px 8px',
-        borderRadius: '18px',
-
-      };
-    case 'large':
-      return {
-        fontSize: '15px',
-        padding: '4px 12px',
-        borderRadius: '16px',
-      };
-    default:
-    case 'medium':
-      return {
-        fontSize: '14px',
-        padding: '2px 10px',
-        borderRadius: '20px',
-      };
-  }
-};
-
-const getTagVariantStyle = (variant: TagProps['variant'], borderColor?: TagProps['borderColor']) => {
-  switch (variant) {
-    case 'border':
-      return {
-        border: `1px solid ${borderColor ?? '#9CC5A1'}`,
-      };
-    default:
-    case 'default':
-      return {
-        border: 'none',
-      };
-  }
-};
-
-const getTagColorStyle = (bgColor: TagProps['bgColor'], textColor: TagProps['textColor']) => {
-  return {
-    backgroundColor: bgColor ?? '#9CC5A1',
-    color: textColor ?? '#DCE1DE',
-  };
-};

--- a/packages/ui-desktop/src/Tag/style.ts
+++ b/packages/ui-desktop/src/Tag/style.ts
@@ -1,0 +1,27 @@
+import { css } from '../styled-system/css';
+
+export const tagBaseStyle = css({
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  fontWeight: '700',
+  cursor: 'pointer',
+});
+
+export const tagSizeStyle = {
+  'small': css({
+    fontSize: '13px',
+    padding: '1px 8px',
+    borderRadius: '18px',
+  }),
+  'medium': css({
+    fontSize: '14px',
+    padding: '2px 10px',
+    borderRadius: '20px',
+  }),
+  'large': css({
+    fontSize: '15px',
+    padding: '4px 12px',
+    borderRadius: '16px',
+  }),
+};


### PR DESCRIPTION
## Overview

<img width="1552" alt="스크린샷 2023-08-13 오전 1 41 45" src="https://github.com/Tech-Frontier/tech-frontier-packages/assets/76990149/d5db7fa6-b919-4d46-91a3-5769221eedea">

variant 는 제거했어요 